### PR TITLE
Save properties just before starting animation

### DIFF
--- a/fiftyshadesof/src/main/java/com/github/florent37/fiftyshadesof/FiftyShadesOf.java
+++ b/fiftyshadesof/src/main/java/com/github/florent37/fiftyshadesof/FiftyShadesOf.java
@@ -6,9 +6,11 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
+
 import com.github.florent37.fiftyshadesof.viewstate.ImageViewState;
 import com.github.florent37.fiftyshadesof.viewstate.TextViewState;
 import com.github.florent37.fiftyshadesof.viewstate.ViewState;
+
 import java.util.HashMap;
 
 /**
@@ -20,6 +22,8 @@ public class FiftyShadesOf {
     private HashMap<View, ViewState> viewsState;
 
     boolean fadein = true;
+
+    private boolean started;
 
     public FiftyShadesOf(Context context) {
         this.context = context;
@@ -76,15 +80,26 @@ public class FiftyShadesOf {
     }
 
     public FiftyShadesOf start() {
-        for (ViewState viewState : viewsState.values()) {
-            viewState.start(fadein);
+        if (!started) {
+            //prepare for starting
+            for (ViewState viewState : viewsState.values()) {
+                viewState.beforeStart();
+            }
+            started = true;
+            //start
+            for (ViewState viewState : viewsState.values()) {
+                viewState.start(fadein);
+            }
         }
         return this;
     }
 
     public FiftyShadesOf stop() {
-        for (ViewState viewState : viewsState.values()) {
-            viewState.stop();
+        if (started) {
+            for (ViewState viewState : viewsState.values()) {
+                viewState.stop();
+            }
+            started = false;
         }
         return this;
     }

--- a/fiftyshadesof/src/main/java/com/github/florent37/fiftyshadesof/viewstate/ImageViewState.java
+++ b/fiftyshadesof/src/main/java/com/github/florent37/fiftyshadesof/viewstate/ImageViewState.java
@@ -16,8 +16,8 @@ public class ImageViewState extends ViewState<ImageView> {
     }
 
     @Override
-    protected void init() {
-        super.init();
+    public void beforeStart() {
+        super.beforeStart();
         this.source = view.getDrawable();
         view.setImageDrawable(new ColorDrawable(Color.TRANSPARENT));
     }

--- a/fiftyshadesof/src/main/java/com/github/florent37/fiftyshadesof/viewstate/TextViewState.java
+++ b/fiftyshadesof/src/main/java/com/github/florent37/fiftyshadesof/viewstate/TextViewState.java
@@ -15,8 +15,8 @@ public class TextViewState extends ViewState<TextView> {
     }
 
     @Override
-    protected void init() {
-        super.init();
+    public void beforeStart() {
+        super.beforeStart();
         this.textColor = view.getTextColors();
         this.darker = view.getTypeface() != null && view.getTypeface().isBold();
     }

--- a/fiftyshadesof/src/main/java/com/github/florent37/fiftyshadesof/viewstate/ViewState.java
+++ b/fiftyshadesof/src/main/java/com/github/florent37/fiftyshadesof/viewstate/ViewState.java
@@ -14,11 +14,6 @@ public abstract class ViewState<V extends View> {
 
     public ViewState(V view) {
         this.view = view;
-        init();
-    }
-
-    protected void init() {
-        this.background = view.getBackground();
     }
 
     protected void restore() {
@@ -26,6 +21,10 @@ public abstract class ViewState<V extends View> {
 
     protected void restoreBackground() {
         this.view.setBackgroundDrawable(background);
+    }
+
+    public void beforeStart(){
+        this.background = view.getBackground();
     }
 
     public void start(boolean fadein) {


### PR DESCRIPTION
If you change a property (like `android:background`) between the creation and the start of the animation, at the end, the background will be the old value of this property.

For example, that can happen if there is many loading in the same view. In this case we don't want to create multiple instance of FiftyShadesOf and ViewState.

The started state is here to handle multiple start before stop. Without this state, the method  `beforeStart` will save gray mask and restore it (in the case of multiple start before stop).